### PR TITLE
Key prefix config 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     prefatory (0.1.2)
-      dry-configurable (~> 0.11.3)
+      dry-configurable (~> 0.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,13 +12,8 @@ GEM
     dalli (2.7.9)
     diff-lcs (1.3)
     docile (1.3.1)
-    dry-configurable (0.11.3)
+    dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.4, >= 0.4.7)
-      dry-equalizer (~> 0.2)
-    dry-core (0.4.9)
-      concurrent-ruby (~> 1.0)
-    dry-equalizer (0.3.0)
     json (2.1.0)
     method_source (0.9.2)
     pry (0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prefatory (0.1.2)
+    prefatory (0.1.3)
       dry-configurable (~> 0.7.0)
 
 GEM

--- a/lib/prefatory.rb
+++ b/lib/prefatory.rb
@@ -10,9 +10,13 @@ module Prefatory
 
     def initialize(key_prefix: nil, storage: nil,
                    config: Prefatory.config)
-      @config = config
-      @config.keys.prefix = key_prefix if key_prefix
-      @storage = storage || Storage::Discover.new(@config.storage, @config.ttl).instance
+      @config = config.dup
+      @key_prefix = key_prefix || @config.keys.prefix
+      @storage = storage || Storage::Discover.new(
+          @config.storage,
+          @config.ttl,
+          key_prefix: @key_prefix
+      ).instance
     end
 
     def find(key)

--- a/lib/prefatory/storage/discover.rb
+++ b/lib/prefatory/storage/discover.rb
@@ -4,22 +4,34 @@ require 'prefatory/errors'
 module Prefatory
   module Storage
     class Discover
-      def initialize(config, ttl=Prefatory.config.ttl)
+      def initialize(config, ttl = Prefatory.config.ttl, key_prefix: Prefatory.config.keys.prefix)
         @config = config
         @ttl = ttl
+        @key_prefix = key_prefix
         @provider = find_provider(config.provider)
       end
 
       def instance
         require_relative "#{@provider}_provider"
-        Object.const_get("Prefatory::Storage::#{@provider.to_s.capitalize}Provider").new(@config.options,
-                                                                                         @ttl,
-                                                                                         marshaler: marshaler)
+
+        class_name = "Prefatory::Storage::#{@provider.to_s.capitalize}Provider"
+        storage_class = Object.const_get(class_name)
+        storage_class.new(
+            @config.options,
+            @ttl,
+            marshaler: marshaler,
+            key_generator: key_generator
+        )
       end
+
       private
 
       def marshaler
         @config.respond_to?(:marshaler) ? @config.marshaler : Marshal
+      end
+
+      def key_generator
+        Prefatory.config.keys.generator.new(@key_prefix)
       end
 
       def find_provider(provider)

--- a/lib/prefatory/storage/hash_provider.rb
+++ b/lib/prefatory/storage/hash_provider.rb
@@ -5,9 +5,10 @@ module Prefatory
     class HashProvider
       def initialize(
           options = nil,
-          ttl = nil,
-          key_generator: Prefatory.config.keys.generator.new
-        )
+          ttl = Prefatory.config.ttl,
+          key_generator: Prefatory.config.keys.generator.new,
+          marshaler: Prefatory.config.storage.marshaler
+      )
         @hash = {}
         @key_generator = key_generator
       end

--- a/lib/prefatory/storage/memcached_provider.rb
+++ b/lib/prefatory/storage/memcached_provider.rb
@@ -6,9 +6,12 @@ module Prefatory
       DEFAULT_SERVER = '127.0.0.1:11211'.freeze
       DEFAULT_OPTIONS = {namespace: Prefatory.config.keys.prefix, compress: true, cache_nils: true}
 
-      def initialize(options = nil, ttl = nil,
-                     key_generator: Prefatory.config.keys.generator.new,
-                     marshaler: Prefatory.config.storage.marshaler)
+      def initialize(
+          options = nil,
+          ttl = Prefatory.config.ttl,
+          key_generator: Prefatory.config.keys.generator.new,
+          marshaler: Prefatory.config.storage.marshaler
+      )
         @ttl = ttl
         @key_generator = key_generator
         @marshaler = marshaler

--- a/lib/prefatory/storage/redis_provider.rb
+++ b/lib/prefatory/storage/redis_provider.rb
@@ -3,9 +3,12 @@ require 'redis'
 module Prefatory
   module Storage
     class RedisProvider
-      def initialize(options=nil, ttl=Prefatory.config.ttl,
-                     key_generator:  Prefatory.config.keys.generator.new(Prefatory.config.keys.prefix),
-                     marshaler: Prefatory.config.storage.marshaler)
+      def initialize(
+          options = nil,
+          ttl = Prefatory.config.ttl,
+          key_generator: Prefatory.config.keys.generator.new,
+          marshaler: Prefatory.config.storage.marshaler
+      )
         options = default_settings(options)
         @ttl = ttl
         @key_generator = key_generator

--- a/lib/prefatory/storage/test_provider.rb
+++ b/lib/prefatory/storage/test_provider.rb
@@ -3,9 +3,12 @@ module Prefatory
     # Used by Specs. This is not safe for production (in any way!) You have been warned.
     class TestProvider
 
-      def initialize(_ttl = nil,
-                     key_generator:  Prefatory.config.keys.generator.new,
-                     marshaler: Prefatory.config.storage.marshaler)
+      def initialize(
+          options = nil,
+          ttl = Prefatory.config.ttl,
+          key_generator: Prefatory.config.keys.generator.new,
+          marshaler: Prefatory.config.storage.marshaler
+      )
         @hash = {}
         @key_generator = key_generator
         @marshaler = marshaler

--- a/lib/prefatory/version.rb
+++ b/lib/prefatory/version.rb
@@ -1,3 +1,3 @@
 module Prefatory
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/prefatory.gemspec
+++ b/prefatory.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "dry-configurable", "~> 0.11.3"
+  spec.add_dependency "dry-configurable", "~> 0.7.0"
 
   spec.add_development_dependency "redis"
   spec.add_development_dependency "dalli"

--- a/spec/prefatory/prefatory_shared.rb
+++ b/spec/prefatory/prefatory_shared.rb
@@ -33,7 +33,6 @@ RSpec.shared_examples 'prefatory_repository' do
       it :saves do
         # Built in types with some random data
         built_in_types.each do |k, v|
-          puts k
           key = repo.save(v)
           expect(repo.find(key)).to eq(v)
         end
@@ -54,7 +53,6 @@ RSpec.shared_examples 'prefatory_repository' do
       it :updates do
         # Built in types with some random data
         built_in_types.each do |k, v|
-          puts "#{k}"
           key = repo.save(v)
           v2 = random_data
           repo.update(key, v2)
@@ -69,7 +67,6 @@ RSpec.shared_examples 'prefatory_repository' do
       it :saves do
         # Built in types with some random data
         built_in_types.each do |k, v|
-          puts "#{k}"
           key = repo.save!(v)
           expect(repo.find!(key)).to eq(v)
         end

--- a/spec/prefatory_spec.rb
+++ b/spec/prefatory_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe Prefatory do
     expect(Prefatory::VERSION).not_to be nil
   end
 
+  context 'with a key_prefix' do
+    it 'does not mutate the global config key_prefix' do
+      initial_key_prefix = Prefatory.config.keys.prefix
+
+      Prefatory::Repository.new(storage: storage, key_prefix: 'foo')
+      expect(Prefatory.config.keys.prefix).to eq(initial_key_prefix)
+    end
+  end
+
   describe :save! do
     let(:storage) do
       s = Prefatory::Storage::TestProvider.new
@@ -27,4 +36,3 @@ RSpec.describe Prefatory do
     end
   end
 end
-


### PR DESCRIPTION
`Storage::Discover` now accepts a `key_prefix` (defaulting to the global config `keys.prefix` value). This `key_prefix` is used to construct a key generator, which `Storage::Discover#instance` passes to the storage class it constructs.

Keep dry-configuration at 0.7 as it conflicts with the older version of dry-validation.